### PR TITLE
Fix OS specific path separator issue

### DIFF
--- a/sslcustomdomain/sslcustomdomain.ps1
+++ b/sslcustomdomain/sslcustomdomain.ps1
@@ -28,7 +28,7 @@ else {
 Write-Host "AppServiceDisplayName"
 Write-Host $AppServiceDisplayName
 
-if ($CertificateFileName -Like "$env:AGENT_TEMPDIRECTORY/*")
+if ($CertificateFileName -Like "$env:AGENT_TEMPDIRECTORY*")
 {
     $CertificateFilePath = $CertificateFileName
 }


### PR DESCRIPTION
By removing trailing slash from the `-like` check.