### PR TITLE
Update version number

### DIFF
--- a/sslcustomdomain/task.json
+++ b/sslcustomdomain/task.json
@@ -9,7 +9,7 @@
     "version": {
         "major": 1,
         "minor": 2,
-        "patch": 0,
+        "patch": 1,
         "isTest": false
     },
     "demands": [


### PR DESCRIPTION
Somehow the extension is updated in the Azure DevOps extension yesterday with version 2.3.2 but the build agent is still using the old scripts with version number 1.2.0. The new script is not being downloaded by the agent. Hopefully this version bump will work.

#3 